### PR TITLE
Update to build with recent clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(Streams CXX)
 # TODO: Make the following more granular once there's wider compiler support for
 # c++14. Note that the absence of "-g" is intentional as the current version of
 # clang (3.4) does not support emitting debug info for auto member functions.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++1y -stdlib=libc++ -Wno-unused-function -pipe")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++1y -Wno-unused-function -pipe -pthread")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -march=native -DNDEBUG")

--- a/source/StreamConversions.h
+++ b/source/StreamConversions.h
@@ -69,7 +69,7 @@ private:
 
 struct PolymorphicHash {
     template<typename T>
-    decltype(auto) operator() (const T& value) {
+    decltype(auto) operator() (const T& value) const {
         return std::hash<T>{}(value);
     }
 };

--- a/source/providers/Overlap.h
+++ b/source/providers/Overlap.h
@@ -8,7 +8,7 @@ namespace provider {
 
 template<typename... Args, typename T, size_t... I, size_t N = sizeof...(Args)>
 NTuple<T, N> rotate_impl(std::tuple<Args...>&& tuple, T&& last, std::index_sequence<I...>) {
-    return {std::forward<T>(std::get<I>(tuple))..., std::forward<T>(last)};
+    return NTuple<T, N>{std::forward<T>(std::get<I>(tuple))..., std::forward<T>(last)};
 }
 
 template<typename... Args, typename T = Head<Args...>, size_t N = sizeof...(Args)>


### PR DESCRIPTION
Just a few minor changes needed for the tests to build with a recent clang version (3.6.0 specifically).