### PR TITLE
Replace to_bool with lambdas, make gcc 5.3 happy

### DIFF
--- a/source/StreamOperators.h
+++ b/source/StreamOperators.h
@@ -23,7 +23,7 @@ auto filter(Predicate&& predicate) {
 }
 
 auto filter() {
-    return filter(to_bool);
+    return filter([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(filter);
@@ -39,7 +39,7 @@ auto take_while(Predicate&& predicate) {
 }
 
 auto take_while() {
-    return take_while(to_bool);
+    return take_while([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(take_while);
@@ -55,7 +55,7 @@ auto drop_while(Predicate&& predicate) {
 }
 
 auto drop_while() {
-    return drop_while(to_bool);
+    return drop_while([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(drop_while);

--- a/source/StreamTerminators.h
+++ b/source/StreamTerminators.h
@@ -221,7 +221,7 @@ auto any(Predicate&& predicate) {
 }
 
 auto any() {
-    return any(to_bool);
+    return any([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(any);
@@ -240,7 +240,7 @@ auto all(Predicate&& predicate) {
 }
 
 auto all() {
-    return all(to_bool);
+    return all([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(all);
@@ -253,7 +253,7 @@ auto none(Predicate&& predicate) {
 }
 
 auto none() {
-    return none(to_bool);
+    return none([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(none);
@@ -266,7 +266,7 @@ auto not_all(Predicate&& predicate) {
 }
 
 auto not_all() {
-    return not_all(to_bool);
+    return not_all([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(not_all);

--- a/source/Utility.h
+++ b/source/Utility.h
@@ -10,10 +10,6 @@
 
 namespace stream {
 
-bool to_bool(bool x) {
-    return x;
-}
-
 template<typename Function>
 struct InvertedPredicate {
     InvertedPredicate(Function&& fn) : function(fn) {}


### PR DESCRIPTION
I was unable to compile a test program using gcc-5, because type inference did not work for the `to_bool` function. Replacing it with a lambda fixes it, and besides it removes one function from the code.

Maybe something like a default parameter would be better ? Like this,

```
template<typename Predicate>
auto filter(Predicate&& predicate = [](bool b){ return b; })
```
