### PR TITLE
Inlined functions to allow using library in several compilation units.

### DIFF
--- a/source/StreamOperators.h
+++ b/source/StreamOperators.h
@@ -13,7 +13,7 @@ namespace op {
         { return operation (std::mem_fn(member)); }
 
 template<typename Predicate>
-auto filter(Predicate&& predicate) {
+inline auto filter(Predicate&& predicate) {
     return make_operator("stream::op::filter", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         return Stream<T>(std::move(
@@ -22,14 +22,14 @@ auto filter(Predicate&& predicate) {
     });
 }
 
-auto filter() {
+inline auto filter() {
     return filter([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(filter);
 
 template<typename Predicate>
-auto take_while(Predicate&& predicate) {
+inline auto take_while(Predicate&& predicate) {
     return make_operator("stream::op::take_while", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         return Stream<T>(std::move(
@@ -38,14 +38,14 @@ auto take_while(Predicate&& predicate) {
     });
 }
 
-auto take_while() {
+inline auto take_while() {
     return take_while([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(take_while);
 
 template<typename Predicate>
-auto drop_while(Predicate&& predicate) {
+inline auto drop_while(Predicate&& predicate) {
     return make_operator("stream::op::drop_while", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         return Stream<T>(std::move(
@@ -54,13 +54,13 @@ auto drop_while(Predicate&& predicate) {
     });
 }
 
-auto drop_while() {
+inline auto drop_while() {
     return drop_while([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(drop_while);
 
-auto slice(std::size_t start, std::size_t end, std::size_t increment = 1) {
+inline auto slice(std::size_t start, std::size_t end, std::size_t increment = 1) {
     return make_operator("stream::op::slice", [=](auto&& stream) {
         using T = StreamType<decltype(stream)>;
         return Stream<T>(std::move(
@@ -69,7 +69,7 @@ auto slice(std::size_t start, std::size_t end, std::size_t increment = 1) {
     });
 }
 
-auto slice_to_end(std::size_t start, std::size_t increment) {
+inline auto slice_to_end(std::size_t start, std::size_t increment) {
     return make_operator("stream::op::slice", [=](auto&& stream) {
         using T = StreamType<decltype(stream)>;
         return Stream<T>(std::move(
@@ -78,16 +78,16 @@ auto slice_to_end(std::size_t start, std::size_t increment) {
     });
 }
 
-auto limit(std::size_t length) {
+inline auto limit(std::size_t length) {
     return slice(0, length).rename("stream::op::limit");
 }
 
-auto skip(std::size_t amount) {
+inline auto skip(std::size_t amount) {
     return slice_to_end(amount, 1).rename("stream::op::skip");
 }
 
 template<typename Function>
-auto map_(Function&& function) {
+inline auto map_(Function&& function) {
     return make_operator("stream::op::map_", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         using Result = std::result_of_t<Function(T&&)>;
@@ -103,7 +103,7 @@ auto map_(Function&& function) {
 CLASS_SPECIALIZATIONS(map_);
 
 template<typename Action>
-auto peek(Action&& action) {
+inline auto peek(Action&& action) {
     return make_operator("stream::op::peek", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         return Stream<T>(std::move(
@@ -115,7 +115,7 @@ auto peek(Action&& action) {
 CLASS_SPECIALIZATIONS(peek);
 
 template<typename Transform>
-auto flat_map(Transform&& transform) {
+inline auto flat_map(Transform&& transform) {
     return make_operator("stream::op::flat_map", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         using Result = std::result_of_t<Transform(T&&)>;
@@ -132,7 +132,7 @@ auto flat_map(Transform&& transform) {
 CLASS_SPECIALIZATIONS(flat_map);
 
 template<typename Equal = std::equal_to<void>>
-auto adjacent_distinct(Equal&& equal = Equal()) {
+inline auto adjacent_distinct(Equal&& equal = Equal()) {
     return make_operator("stream::op::adjacent_distinct", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         return Stream<T>(std::move(
@@ -142,7 +142,7 @@ auto adjacent_distinct(Equal&& equal = Equal()) {
 }
 
 template<typename Subtractor = std::minus<void>>
-auto adjacent_difference(Subtractor&& subtract = Subtractor()) {
+inline auto adjacent_difference(Subtractor&& subtract = Subtractor()) {
     return make_operator("stream::op::adjacent_difference", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         using Result = std::result_of_t<Subtractor(T&, T&)>;
@@ -153,7 +153,7 @@ auto adjacent_difference(Subtractor&& subtract = Subtractor()) {
 }
 
 template<typename Adder = std::plus<void>>
-auto partial_sum(Adder&& add = Adder()) {
+inline auto partial_sum(Adder&& add = Adder()) {
     return make_operator("stream::op::partial_sum", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         return Stream<T>(std::move(
@@ -163,7 +163,7 @@ auto partial_sum(Adder&& add = Adder()) {
 }
 
 template<typename U>
-auto concat(Stream<U>&& tail) {
+inline auto concat(Stream<U>&& tail) {
     return make_operator("stream::op::concat", [tail = std::move(tail)] (auto&& head) mutable {
         if(!tail.occupied())
             throw VacantStreamException("stream::op::concat");
@@ -183,7 +183,7 @@ auto concat(Stream<U>&& tail) {
 }
 
 template<typename Iterator>
-auto concat(Iterator begin, Iterator end) {
+inline auto concat(Iterator begin, Iterator end) {
     return make_operator("stream::op::concat", [=](auto&& stream) {
         using I = IteratorType<Iterator>;
         using T = StreamType<decltype(stream)>;
@@ -195,7 +195,7 @@ auto concat(Iterator begin, Iterator end) {
 }
 
 template<size_t N>
-auto group() {
+inline auto group() {
     return make_operator("stream::op::group", [=](auto&& stream) {
         using T = StreamType<decltype(stream)>;
         using G = provider::detail::GroupResult<T, N>;
@@ -204,11 +204,11 @@ auto group() {
     });
 }
 
-auto pairwise() {
+inline auto pairwise() {
     return group<2>().rename("stream::op::pairwise");
 }
 
-auto group(size_t N) {
+inline auto group(size_t N) {
     return make_operator("stream::op::group", [=](auto&& stream) {
         using T = StreamType<decltype(stream)>;
         using G = std::vector<T>;
@@ -218,7 +218,7 @@ auto group(size_t N) {
 }
 
 template<size_t N>
-auto overlap() {
+inline auto overlap() {
     return make_operator("stream::op::overlap", [=](auto&& stream) {
         using T = StreamType<decltype(stream)>;
         using O = NTuple<T, N>;
@@ -227,7 +227,7 @@ auto overlap() {
     });
 }
 
-auto overlap(size_t N) {
+inline auto overlap(size_t N) {
     return make_operator("stream::op::overlap", [=](auto&& stream) {
         using T = StreamType<decltype(stream)>;
         using O = std::deque<T>;
@@ -237,7 +237,7 @@ auto overlap(size_t N) {
 }
 
 template<typename R, typename Function = provider::detail::Zipper>
-auto zip_with(Stream<R>&& right, Function&& zipper = Function()) {
+inline auto zip_with(Stream<R>&& right, Function&& zipper = Function()) {
     return make_operator("stream::op::zip_with", [right = std::move(right), zipper]
     (auto&& left) mutable {
         if(!right.occupied())
@@ -258,7 +258,7 @@ auto zip_with(Stream<R>&& right, Function&& zipper = Function()) {
 namespace detail {
 
 template<template<typename...> class Provider, typename T, typename Less>
-auto make_set_operator(const std::string& name, Stream<T>&& right, Less&& less) {
+inline auto make_set_operator(const std::string& name, Stream<T>&& right, Less&& less) {
     return make_operator(name, [name, right = std::move(right), less] (auto&& left) mutable {
         if(!right.occupied())
             throw VacantStreamException(name);
@@ -276,36 +276,36 @@ auto make_set_operator(const std::string& name, Stream<T>&& right, Less&& less) 
 } /* namespace detail */
 
 template<typename T, typename Less = std::less<T>>
-auto merge_with(Stream<T>&& right, Less&& less = Less()) {
+inline auto merge_with(Stream<T>&& right, Less&& less = Less()) {
     return detail::make_set_operator<provider::Merge>(
         "stream::op::merge_with", std::move(right), std::forward<Less>(less));
 }
 
 template<typename T, typename Less = std::less<T>>
-auto union_with(Stream<T>&& right, Less&& less = Less()) {
+inline auto union_with(Stream<T>&& right, Less&& less = Less()) {
     return detail::make_set_operator<provider::Union>(
         "stream::op::union_with", std::move(right), std::forward<Less>(less));
 }
 
 template<typename T, typename Less = std::less<T>>
-auto intersect_with(Stream<T>&& right, Less&& less = Less()) {
+inline auto intersect_with(Stream<T>&& right, Less&& less = Less()) {
     return detail::make_set_operator<provider::Intersection>(
         "stream::op::intersect_with", std::move(right), std::forward<Less>(less));
 }
 
 template<typename T, typename Less = std::less<T>>
-auto difference_with(Stream<T>&& right, Less&& less = Less()) {
+inline auto difference_with(Stream<T>&& right, Less&& less = Less()) {
     return detail::make_set_operator<provider::Difference>(
         "stream::op::difference_with", std::move(right), std::forward<Less>(less));
 }
 
 template<typename T, typename Less = std::less<T>>
-auto symmetric_difference_with(Stream<T>&& right, Less&& less = Less()) {
+inline auto symmetric_difference_with(Stream<T>&& right, Less&& less = Less()) {
     return detail::make_set_operator<provider::SymmetricDifference>(
         "stream::op::symmetric_difference_with", std::move(right), std::forward<Less>(less));
 }
 
-auto state_point() {
+inline auto state_point() {
     return make_operator("stream::op::state_point", [=](auto&& stream) {
         using T = StreamType<decltype(stream)>;
         return Stream<T>(std::move(make_stream_provider<provider::Stateful, T>(
@@ -314,7 +314,7 @@ auto state_point() {
 }
 
 template<typename Less = std::less<void>>
-auto sort(Less&& less = Less()) {
+inline auto sort(Less&& less = Less()) {
     return make_operator("stream::op::sort", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         return Stream<T>(std::move(
@@ -324,7 +324,7 @@ auto sort(Less&& less = Less()) {
 }
 
 template<typename Less = std::less<void>>
-auto distinct(Less&& less = Less()) {
+inline auto distinct(Less&& less = Less()) {
     return make_operator("stream::op::distinct", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         return Stream<T>(std::move(

--- a/source/StreamTerminators.h
+++ b/source/StreamTerminators.h
@@ -11,7 +11,7 @@ namespace op {
         { return operation (std::mem_fn(member)); }
 
 template<typename Function>
-auto for_each(Function&& function) {
+inline auto for_each(Function&& function) {
     return make_terminator("stream::op::for_each", [=](auto&& stream) mutable {
         auto& source = stream.getSource();
         while(source->advance()) {
@@ -23,7 +23,7 @@ auto for_each(Function&& function) {
 
 CLASS_SPECIALIZATIONS(for_each);
 
-auto count() {
+inline auto count() {
     return make_terminator("stream::op::count", [=](auto&& stream) {
         auto& source = stream.getSource();
         size_t count = 0;
@@ -36,7 +36,7 @@ auto count() {
 }
 
 template<typename U, typename Accumulator>
-auto identity_reduce(const U& identity, Accumulator&& accumulator) {
+inline auto identity_reduce(const U& identity, Accumulator&& accumulator) {
     return make_terminator("stream::op::identity_reduce", [=](auto&& stream) mutable {
         auto& source = stream.getSource();
         U result = identity;
@@ -48,7 +48,7 @@ auto identity_reduce(const U& identity, Accumulator&& accumulator) {
 }
 
 template<typename Accumulator>
-auto reduce(Accumulator&& accumulator) {
+inline auto reduce(Accumulator&& accumulator) {
     return make_terminator("stream::op::reduce", [=](auto&& stream) mutable {
         auto& source = stream.getSource();
         if(source->advance()) {
@@ -62,7 +62,7 @@ auto reduce(Accumulator&& accumulator) {
 }
 
 template<typename IdentityFn, typename Accumulator>
-auto reduce(IdentityFn&& identityFn, Accumulator&& accumulator) {
+inline auto reduce(IdentityFn&& identityFn, Accumulator&& accumulator) {
     return make_terminator("stream::op::reduce", [=](auto&& stream) mutable {
         auto& source = stream.getSource();
         if(source->advance()) {
@@ -75,7 +75,7 @@ auto reduce(IdentityFn&& identityFn, Accumulator&& accumulator) {
     });
 }
 
-auto first() {
+inline auto first() {
     return make_terminator("stream::op::first", [=](auto&& stream) {
         auto& source = stream.getSource();
         if(source->advance()) {
@@ -86,46 +86,46 @@ auto first() {
     });
 }
 
-auto last() {
+inline auto last() {
     return reduce([](auto&& first, auto&& second) { return second; })
         .rename("stream::op::last");
 }
 
-auto nth(size_t index) {
+inline auto nth(size_t index) {
     return (skip(index) | first()).rename("stream::op::nth");
 }
 
-auto sum() {
+inline auto sum() {
     return reduce(std::plus<void>())
         .rename("stream::op::sum");
 }
 
 template<typename T>
-auto sum(const T& identity) {
+inline auto sum(const T& identity) {
     return identity_reduce(identity, std::plus<T>())
         .rename("stream::op::sum");
 }
 
-auto product() {
+inline auto product() {
     return reduce(std::multiplies<void>())
         .rename("stream::op::product");
 }
 
 template<typename T>
-auto product(const T& identity) {
+inline auto product(const T& identity) {
     return identity_reduce(identity, std::multiplies<T>())
         .rename("stream::op::product");
 }
 
 template<typename Less = std::less<void>>
-auto max(Less&& less = Less()) {
+inline auto max(Less&& less = Less()) {
     return reduce([=](const auto& a, const auto& b) {
         return less(a, b) ? b : a;
     }).rename("stream::op::max");
 }
 
 template<typename Function, typename Less = std::less<void>>
-auto max_by(Function&& function, Less&& less = Less()) {
+inline auto max_by(Function&& function, Less&& less = Less()) {
     /* Pair is (max, max_elem) */
     auto to_pair = [function](auto&& x) { return std::make_pair(function(x), x); };
     auto next = [function, less](auto&& accumulated, auto&& value) {
@@ -142,14 +142,14 @@ auto max_by(Function&& function, Less&& less = Less()) {
 }
 
 template<typename Less = std::less<void>>
-auto min(Less&& less = Less()) {
+inline auto min(Less&& less = Less()) {
     return reduce([=](const auto& a, const auto& b) {
         return less(a, b) ? a : b;
     }).rename("stream::op::min");
 }
 
 template<typename Function, typename Less = std::less<void>>
-auto min_by(Function&& function, Less&& less = Less()) {
+inline auto min_by(Function&& function, Less&& less = Less()) {
     /* Pair is (min, min_elem) */
     auto to_pair = [function](auto&& x) { return std::make_pair(function(x), x); };
     auto next = [function, less](auto&& accumulated, auto&& value) {
@@ -166,7 +166,7 @@ auto min_by(Function&& function, Less&& less = Less()) {
 }
 
 template<typename Less = std::less<void>>
-auto minmax(Less&& less = Less()) {
+inline auto minmax(Less&& less = Less()) {
     auto to_pair = [](auto&& x) { return std::make_pair(x, x); };
     auto next_minmax = [less](auto&& accumulated, auto&& value) {
         using T = std::remove_reference_t<decltype(value)>;
@@ -183,7 +183,7 @@ auto minmax(Less&& less = Less()) {
 }
 
 template<typename Function, typename Less = std::less<void>>
-auto minmax_by(Function&& function, Less&& less = Less()) {
+inline auto minmax_by(Function&& function, Less&& less = Less()) {
     /* Pair is ((min, min_elem), (max, max_elem)) */
     auto to_pair = [function](auto&& x) {
       auto fx = function(x);
@@ -208,7 +208,7 @@ auto minmax_by(Function&& function, Less&& less = Less()) {
 }
 
 template<typename Predicate>
-auto any(Predicate&& predicate) {
+inline auto any(Predicate&& predicate) {
     return make_terminator("stream::op::any", [=](auto&& stream) mutable {
         auto& source = stream.getSource();
         while(source->advance()) {
@@ -220,14 +220,14 @@ auto any(Predicate&& predicate) {
     });
 }
 
-auto any() {
+inline auto any() {
     return any([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(any);
 
 template<typename Predicate>
-auto all(Predicate&& predicate) {
+inline auto all(Predicate&& predicate) {
     return make_terminator("stream::op::all", [=](auto&& stream) mutable {
         auto& source = stream.getSource();
         while(source->advance()) {
@@ -239,40 +239,40 @@ auto all(Predicate&& predicate) {
     });
 }
 
-auto all() {
+inline auto all() {
     return all([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(all);
 
 template<typename Predicate>
-auto none(Predicate&& predicate) {
+inline auto none(Predicate&& predicate) {
     return any(std::forward<Predicate>(predicate))
         .then([](bool x) { return !x; })
         .rename("stream::op::none");
 }
 
-auto none() {
+inline auto none() {
     return none([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(none);
 
 template<typename Predicate>
-auto not_all(Predicate&& predicate) {
+inline auto not_all(Predicate&& predicate) {
     return all(std::forward<Predicate>(predicate))
         .then([](bool x) { return !x; })
         .rename("stream::op::not_all");
 }
 
-auto not_all() {
+inline auto not_all() {
     return not_all([](bool b){ return b; });
 }
 
 CLASS_SPECIALIZATIONS(not_all);
 
 template<typename OutputIterator>
-auto copy_to(OutputIterator out) {
+inline auto copy_to(OutputIterator out) {
     return make_terminator("stream::op::copy_to", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         auto& source = stream.getSource();
@@ -285,7 +285,7 @@ auto copy_to(OutputIterator out) {
 }
 
 template<typename OutputIterator>
-auto move_to(OutputIterator out) {
+inline auto move_to(OutputIterator out) {
     return make_terminator("stream::op::move_to", [=](auto&& stream) mutable {
         using T = StreamType<decltype(stream)>;
         auto& source = stream.getSource();
@@ -297,7 +297,7 @@ auto move_to(OutputIterator out) {
     });
 }
 
-auto print_to(std::ostream& os, const char* delimiter = " ") {
+inline auto print_to(std::ostream& os, const char* delimiter = " ") {
     return make_terminator("stream::op::print_to", [&os, delimiter](auto&& stream) -> std::ostream& {
         using T = StreamType<decltype(stream)>;
         stream | copy_to(std::ostream_iterator<T>(os, delimiter));
@@ -305,7 +305,7 @@ auto print_to(std::ostream& os, const char* delimiter = " ") {
     });
 }
 
-auto random_sample(size_t size) {
+inline auto random_sample(size_t size) {
     return make_terminator("stream::op::random_sample", [=](auto&& stream) {
         using T = StreamType<decltype(stream)>;
         auto& source = stream.getSource();
@@ -340,7 +340,7 @@ auto random_sample(size_t size) {
     });
 }
 
-auto random_element() {
+inline auto random_element() {
     return random_sample(1)
         .then([](auto&& vec) {
             if(vec.empty()) {

--- a/source/Utility.h
+++ b/source/Utility.h
@@ -89,11 +89,11 @@ std::ostream& operator<< (std::ostream& os, const std::tuple<Args...>& tuple) {
 }
 
 template<typename Function, typename... Types>
-auto apply_tuple(Function&& function, const std::tuple<Types...>& tuple)
+inline auto apply_tuple(Function&& function, const std::tuple<Types...>& tuple)
         -> decltype(function(std::declval<Types>()...));
 
 template<typename Function, typename L, typename R>
-auto apply_tuple(Function&& function, const std::pair<L, R>& pair)
+inline auto apply_tuple(Function&& function, const std::pair<L, R>& pair)
         -> decltype(function(pair.first, pair.second));
 
 template<typename Function>

--- a/source/UtilityImpl.h
+++ b/source/UtilityImpl.h
@@ -120,7 +120,7 @@ struct SplatTuple<Return, Function, last, last, Tuple, Args...> {
 };
 
 template<typename Function, typename... Types>
-auto apply_tuple(Function&& function, const std::tuple<Types...>& tuple)
+inline auto apply_tuple(Function&& function, const std::tuple<Types...>& tuple)
         -> decltype(function(std::declval<Types>()...)) {
 
     using Return = decltype(function(std::declval<Types>()...));
@@ -131,7 +131,7 @@ auto apply_tuple(Function&& function, const std::tuple<Types...>& tuple)
 }
 
 template<typename Function, typename L, typename R>
-auto apply_tuple(Function&& function, const std::pair<L, R>& pair) {
+inline auto apply_tuple(Function&& function, const std::pair<L, R>& pair) {
     return function(pair.first, pair.second);
 }
 
@@ -203,7 +203,7 @@ struct ArgsToTuple<last, last, SplattableTuple<Types...>> {
 };
 
 template<typename... Args>
-auto args2tuple(Args&&... args) {
+inline auto args2tuple(Args&&... args) {
     return ArgsToTuple<0, sizeof...(Args)-1, Args...>
         ::tuplize(std::forward<Args>(args)...);
 }

--- a/source/providers/Recurrence.h
+++ b/source/providers/Recurrence.h
@@ -11,12 +11,12 @@ namespace provider {
 namespace detail {
 
 template<typename Function, typename Array, size_t... I>
-auto apply_impl(Function&& function, Array& args, std::index_sequence<I...>) {
+inline auto apply_impl(Function&& function, Array& args, std::index_sequence<I...>) {
     return function(std::get<I>(args)...);
 }
 
 template<typename Function, typename T, size_t N>
-auto apply(Function&& function, std::array<T, N>& args) {
+inline auto apply(Function&& function, std::array<T, N>& args) {
     return apply_impl(std::forward<Function>(function), args,
                       std::make_index_sequence<N>());
 }


### PR DESCRIPTION
In order to use the library within several compilation units without the linker puking the functions should be inline to tell the compiler that they violate the one definition rule.