### PR TITLE
undefined min/max in StreamTerminators.h for msvc

### DIFF
--- a/source/StreamTerminators.h
+++ b/source/StreamTerminators.h
@@ -1,6 +1,13 @@
 #ifndef SCHEINERMAN_STREAM_STREAM_TERMINATORS_H
 #define SCHEINERMAN_STREAM_STREAM_TERMINATORS_H
 
+#ifdef _MSC_VER
+#define MAX_ORIGINAL max
+#define MIN_ORIGINAL min
+#undef max
+#undef min
+#endif // _MSC_VER
+
 namespace stream {
 namespace op {
 
@@ -358,3 +365,8 @@ inline auto random_element() {
 
 
 #endif
+
+#ifdef _MSC_VER
+#define max MAX_ORIGINAL
+#define min MIN_ORIGINAL
+#endif // _MSC_VER


### PR DESCRIPTION
Hello,
while working on Windows and compiling with MSVC(1921), and using common windows headers, i couldn't compile while using Streams. This is due to the implementation of
```C++
inline auto max(Less&& less = Less())
```
and
```C++
inline auto min(Less&& less = Less())
```
in ```StreamTerminators.h```.<br>
```min``` and ```max``` are already defined as macros
```C++
#define max(a,b)            (((a) > (b)) ? (a) : (b))
```
and
```C++
#define min(a,b)            (((a) < (b)) ? (a) : (b))
```
in ```minwindef.h```.<br>
I got it working by first, undefining, and at the end of the file, redefining ```min``` and ```max```.