### PR TITLE
Allow finite Generator streams by indicating end of stream via a std::out_of_range exception

### DIFF
--- a/source/providers/Generate.h
+++ b/source/providers/Generate.h
@@ -20,8 +20,14 @@ public:
     }
 
     bool advance_impl() override {
-        current_ = std::make_shared<T>(generator_());
-        return true;
+        try {
+            current_ = std::make_shared<T>(generator_());
+            return true;
+        }
+        catch (const std::out_of_range& e) {
+            // out_of_range indicates end of stream
+            return false;
+        }
     }
 
     PrintInfo print(std::ostream& os, int indent) const override {


### PR DESCRIPTION
I'd like to be able to have a generator stream that's not infinite. 
It's natural to use std::out_of_range to signal the end as most vector based generator function will throw std::out_of_range when the index surpass end of vector.